### PR TITLE
adds split-deploy job

### DIFF
--- a/spaws/orb.yml
+++ b/spaws/orb.yml
@@ -1,5 +1,3 @@
-# This code is licensed from CircleCI to the user under the MIT license. See
-# https://circleci.com/orbs/registry/licensing for details.
 version: 2.1
 
 orbs:
@@ -15,7 +13,6 @@ jobs:
       bucket:
         description: "S3 bucket to pull from"
         type: string
-        default: "$CONFIG_BUCKET"
       environment:
         description: "Which environment's config file"
         type: string
@@ -44,7 +41,6 @@ jobs:
       bucket:
         description: "S3 bucket to deploy to"
         type: string
-        default: "$ARTIFACT_BUCKET"
       tarfile:
         description: "Name of build tarfile (should end in .tar.gz)"
         type: string
@@ -65,3 +61,52 @@ jobs:
       - aws-s3/copy:
           from: '<< parameters.working-dir >>/workspace/latest.txt'
           to: 's3://<< parameters.bucket >>/builds/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BRANCH/latest.txt'
+  split-deploy:
+    description: Deploys two build tarfiles to a deployment artifact bucket
+    executor: aws-executor
+    parameters:
+      bucket:
+        description: "S3 bucket to deploy to"
+        type: string
+      first-tarfile:
+        description: "Name of first build tarfile - should end in .tar.gz"
+        type: string
+        default: "build.tar.gz"
+      second-tarfile:
+        description: "Name of second build tarfile - should end in .tar.gz (defaults to using the same file as the first)"
+        type: string
+        default: "build.tar.gz"
+      first-project-suffix:
+        description: "Name of first project spinoff"
+        type: string
+      second-project-suffix:
+        description: "Name of second project spinoff"
+        type: string
+      working-dir:
+        description: "Working directory"
+        type: string
+        default: "~/repo"
+    working_directory: << parameters.working-dir >>
+    steps:
+      - attach_workspace:
+          at: workspace
+      - run: echo "first deploy"
+      - aws-s3/copy:
+          from: '<< parameters.working-dir >>/workspace/<< parameters.first-tarfile >>'
+          to: 's3://<< parameters.bucket >>/builds/$CIRCLE_PROJECT_REPONAME-<< parameters.first-project-suffix >>/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM.tar.gz'
+      - run: echo "$CIRCLE_BUILD_NUM.tar.gz" > << parameters.working-dir >>/workspace/latest.txt
+      - run: aws s3api put-object-tagging --bucket << parameters.bucket >> --key builds/$CIRCLE_PROJECT_REPONAME-<< parameters.first-project-suffix >>/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM.tar.gz --tagging "TagSet=[{Key=checksum,Value=$CIRCLE_SHA1}]"
+      - aws-s3/copy:
+          from: '<< parameters.working-dir >>/workspace/latest.txt'
+          to: 's3://<< parameters.bucket >>/builds/$CIRCLE_PROJECT_REPONAME-<< parameters.first-project-suffix >>/$CIRCLE_BRANCH/latest.txt'
+      - run: echo "second deploy"
+      - aws-s3/copy:
+          from: '<< parameters.working-dir >>/workspace/<< parameters.second-tarfile >>'
+          to: 's3://<< parameters.bucket >>/builds/$CIRCLE_PROJECT_REPONAME-<< parameters.second-project-suffix >>/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM.tar.gz'
+      - run: echo "$CIRCLE_BUILD_NUM.tar.gz" > << parameters.working-dir >>/workspace/latest.txt
+      - run: aws s3api put-object-tagging --bucket << parameters.bucket >> --key builds/$CIRCLE_PROJECT_REPONAME-<< parameters.second-project-suffix >>/$CIRCLE_BRANCH/$CIRCLE_BUILD_NUM.tar.gz --tagging "TagSet=[{Key=checksum,Value=$CIRCLE_SHA1}]"
+      - aws-s3/copy:
+          from: '<< parameters.working-dir >>/workspace/latest.txt'
+          to: 's3://<< parameters.bucket >>/builds/$CIRCLE_PROJECT_REPONAME-<< parameters.second-project-suffix >>/$CIRCLE_BRANCH/latest.txt'
+          
+

--- a/spaws/orb.yml
+++ b/spaws/orb.yml
@@ -1,3 +1,5 @@
+# This code is licensed from CircleCI to the user under the MIT license. See
+# https://circleci.com/orbs/registry/licensing for details.
 version: 2.1
 
 orbs:
@@ -13,6 +15,7 @@ jobs:
       bucket:
         description: "S3 bucket to pull from"
         type: string
+        default: "$CONFIG_BUCKET"
       environment:
         description: "Which environment's config file"
         type: string
@@ -41,6 +44,7 @@ jobs:
       bucket:
         description: "S3 bucket to deploy to"
         type: string
+        default: "$ARTIFACT_BUCKET"
       tarfile:
         description: "Name of build tarfile (should end in .tar.gz)"
         type: string


### PR DESCRIPTION
needed for deploying eigenlicht with daisy - adds `split-deploy` job that lets you push artifacts to two separate S3 buckets

unfortunately, I'm still unable to promote the Orb in circle