### PR TITLE
bump ubuntu base image for nimoy to 20.04

### DIFF
--- a/nimoy/orb.yml
+++ b/nimoy/orb.yml
@@ -14,7 +14,7 @@ executors:
             image: <<parameters.image>>
         parameters:
             image:
-                default: ubuntu-1604:201903-01
+                default: ubuntu-2004:current
                 type: string
             use-docker-layer-caching:
                 default: true


### PR DESCRIPTION
This pr bumps the version of ubuntu used by the executor for the nimoy orb. Build currently using this orb are broken because it is pointing at a currently unsupported version of ubuntu.

Once this pr has been merged we will be required to run `make orb=nimoy promote` to push the latest version to the circle ci orbs repo