### PR TITLE
bump versions for multiple dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/base:2020.01
+FROM cimg/base:2022.08
 
 USER root
 

--- a/nimoy/orb2.yml
+++ b/nimoy/orb2.yml
@@ -12,10 +12,10 @@ commands:
                 default: "staging"
                 type: string
             target:
-                default: artifact
+                default: ""
                 type: string
                 description: |
-                    What Docker build stage should be targeted? Default: "artifact"
+                    What Docker build stage should be targeted? Default: ""
             account-url:
                 default: AWS_ECR_ACCOUNT_URL
                 type: env_var_name
@@ -116,7 +116,7 @@ commands:
                     #build
                     docker build \
                         --progress=plain \
-                        --target=<<parameters.target>> \
+                        <<#parameters.target>>--target=<<parameters.target>><</parameters.target>> \
                         --build-arg AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
                         --build-arg AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
                         --build-arg SHA=${CIRCLE_SHA1} \
@@ -142,7 +142,7 @@ commands:
 executors:
     default:
         docker:
-          - image: spoonflower/circleci:latest
+          - image: spoonflower/circleci:0.0.1
 
 jobs:
     nimoy:
@@ -158,10 +158,10 @@ jobs:
                 default: "staging"
                 type: string
             target:
-                default: artifact
+                default: ""
                 type: string
                 description: |
-                    What Docker build stage should be targeted? Default: "artifact"
+                    What Docker build stage should be targeted? Default: ""
             account-url:
                 default: AWS_ECR_ACCOUNT_URL
                 description: |

--- a/node_12/orb.yml
+++ b/node_12/orb.yml
@@ -11,13 +11,13 @@ executors:
       - image: circleci/python:3.7.1
   project-executor:
     docker:
-      - image: 773459762593.dkr.ecr.us-east-1.amazonaws.com/base/ubuntu-xenial-node-12:latest
+      - image: 773459762593.dkr.ecr.us-east-1.amazonaws.com/base/ubuntu-xenial-node-12:0.0.1
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
   test-executors:
     docker:
-      - image: 773459762593.dkr.ecr.us-east-1.amazonaws.com/base/ubuntu-xenial-node-12:latest
+      - image: 773459762593.dkr.ecr.us-east-1.amazonaws.com/base/ubuntu-xenial-node-12:0.0.1
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
bump image tag for ubuntu-xenial-node-12 in node_12 orb and stop using the `latest` tag